### PR TITLE
sync recreated clusters using cluster ID

### DIFF
--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	k8sclientcmd "k8s.io/client-go/tools/clientcmd"
+
+	"github.com/DO-Solutions/kubectl-doks/pkg/kubeconfig"
 )
 
 // Mock kubeconfig data
@@ -130,6 +132,13 @@ func TestSaveCommand(t *testing.T) {
 	assert.Contains(t, updatedKubeconfig.AuthInfos, "do-sfo3-new-cluster-admin", "User for new cluster should exist")
 	// Verify old user still exists
 	assert.Contains(t, updatedKubeconfig.AuthInfos, "do-nyc1-old-cluster-admin", "Old user should still exist")
+
+	// Verify cluster ID extension
+	newCluster, exists := updatedKubeconfig.Clusters["do-sfo3-new-cluster"]
+	require.True(t, exists, "New cluster config should exist")
+	id, found := kubeconfig.GetClusterID(newCluster)
+	assert.True(t, found, "Cluster ID extension should be found")
+	assert.Equal(t, "new-cluster-id", id, "Cluster ID should match")
 }
 
 func TestSaveCommandContextHandling(t *testing.T) {
@@ -289,6 +298,13 @@ users: []
 		updatedKubeconfig, err := k8sclientcmd.Load(updatedBytes)
 		require.NoError(t, err)
 		assert.Equal(t, "do-sfo3-new-cluster", updatedKubeconfig.CurrentContext)
+
+		// Verify cluster ID extension
+		newCluster, exists := updatedKubeconfig.Clusters["do-sfo3-new-cluster"]
+		require.True(t, exists, "New cluster config should exist")
+		id, found := kubeconfig.GetClusterID(newCluster)
+		assert.True(t, found, "Cluster ID extension should be found")
+		assert.Equal(t, "new-cluster-id", id, "Cluster ID should match")
 	})
 
 	t.Run("save all with one new cluster and existing current context", func(t *testing.T) {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -55,7 +55,6 @@ is synchronized with the clusters' credentials.`,
 			}
 		}
 
-
 		prunedConfigBytes, removedContexts, err := kubeconfig.PruneConfig(existingConfigBytes, allClusters)
 		if err != nil {
 			return fmt.Errorf("pruning kubeconfig: %w", err)
@@ -83,7 +82,7 @@ is synchronized with the clusters' credentials.`,
 				if id, found := kubeconfig.GetClusterID(existingCluster); !found || id != cluster.ID {
 					needsUpdate = true
 					if verbose {
-						fmt.Printf("Notice: Cluster '%s' has a new ID, updating kubeconfig.\n", cluster.Name)
+						fmt.Printf("Notice: Cluster '%s' has a new ID, will resync config.\n", cluster.Name)
 					}
 				}
 			}
@@ -184,7 +183,7 @@ is synchronized with the clusters' credentials.`,
 				return fmt.Errorf("writing updated kubeconfig: %w", err)
 			}
 			if verbose {
-				fmt.Printf("Notice: Successfully synced %d DOKS cluster(s) to your kubeconfig file.\n", len(allClusters))
+				fmt.Printf("Notice: Successfully synced %d DOKS cluster(s) to your kubeconfig file.\n", len(addedContexts)+len(removedContexts))
 			}
 		} else {
 			if verbose {

--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"github.com/DO-Solutions/kubectl-doks/pkg/kubeconfig"
+	k8sclientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -172,6 +174,19 @@ func TestSyncCommand(t *testing.T) {
 	assert.Contains(t, updatedKubeconfig.AuthInfos, "do-nyc1-doks-cluster-1-admin", "User for cluster 1 should exist")
 	assert.Contains(t, updatedKubeconfig.AuthInfos, "do-sfo3-doks-cluster-2-admin", "User for cluster 2 should exist")
 	assert.NotContains(t, updatedKubeconfig.AuthInfos, "do-nyc1-old-cluster-admin", "Old user should have been removed")
+
+	// Verify cluster ID extension was added
+	cluster1, exists := updatedKubeconfig.Clusters["do-nyc1-doks-cluster-1"]
+	require.True(t, exists)
+	cluster1ID, found := kubeconfig.GetClusterID(cluster1)
+	assert.True(t, found)
+	assert.Equal(t, "cluster-1-id", cluster1ID)
+
+	cluster2, exists := updatedKubeconfig.Clusters["do-sfo3-doks-cluster-2"]
+	require.True(t, exists)
+	cluster2ID, found := kubeconfig.GetClusterID(cluster2)
+	assert.True(t, found)
+	assert.Equal(t, "cluster-2-id", cluster2ID)
 }
 
 func TestSyncCommandContextHandling(t *testing.T) {
@@ -317,4 +332,129 @@ func TestSyncCommandContextHandling(t *testing.T) {
 		assert.NotContains(t, updatedKubeconfig.AuthInfos, "do-nyc1-old-cluster-admin", "Old user should have been removed")
 		assert.Empty(t, updatedKubeconfig.CurrentContext, "Current context should be empty")
 	})
+}
+
+func TestSyncCommandWithRecreatedCluster(t *testing.T) {
+	// 1. Create a mock API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/kubernetes/clusters" {
+			clusters := []*godo.KubernetesCluster{
+				{
+					ID:         "new-recreated-cluster-id",
+					Name:       "doks-recreated-cluster",
+					RegionSlug: "nyc1",
+				},
+			}
+			response := struct {
+				KubernetesClusters []*godo.KubernetesCluster `json:"kubernetes_clusters"`
+			}{
+				KubernetesClusters: clusters,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		} else if r.URL.Path == "/v2/kubernetes/clusters/new-recreated-cluster-id/kubeconfig" {
+			fmt.Fprint(w, `
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://new-recreated-cluster-server
+  name: do-nyc1-doks-recreated-cluster
+contexts:
+- context:
+    cluster: do-nyc1-doks-recreated-cluster
+    user: do-nyc1-doks-recreated-cluster-admin
+  name: do-nyc1-doks-recreated-cluster
+current-context: do-nyc1-doks-recreated-cluster
+kind: Config
+users:
+- name: do-nyc1-doks-recreated-cluster-admin
+  user:
+    token: new-recreated-cluster-token
+`)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	// 2. Set up temporary environment and flags
+	tmpDir := t.TempDir()
+
+	// Create mock kubeconfig with an old cluster ID
+	kubeConfigDir := filepath.Join(tmpDir, ".kube")
+	require.NoError(t, os.MkdirAll(kubeConfigDir, 0755))
+	finalKubeConfigPath := filepath.Join(kubeConfigDir, "config")
+
+	// Create a kubeconfig object programmatically to add the extension
+	initialConfig := k8sclientcmdapi.NewConfig()
+	clusterName := "do-nyc1-doks-recreated-cluster"
+	cluster := k8sclientcmdapi.NewCluster()
+	cluster.Server = "https://old-recreated-cluster-server"
+	kubeconfig.SetClusterID(cluster, "old-recreated-cluster-id")
+	initialConfig.Clusters[clusterName] = cluster
+
+	// Add context and user for completeness
+	contextName := clusterName
+	context := k8sclientcmdapi.NewContext()
+	context.Cluster = clusterName
+	context.AuthInfo = clusterName + "-admin"
+	initialConfig.Contexts[contextName] = context
+	initialConfig.CurrentContext = contextName
+
+	authInfo := k8sclientcmdapi.NewAuthInfo()
+	authInfo.Token = "old-token"
+	initialConfig.AuthInfos[context.AuthInfo] = authInfo
+
+	initialBytes, err := k8sclientcmd.Write(*initialConfig)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(finalKubeConfigPath, initialBytes, 0600))
+
+	// Override HOME to our temp dir
+	originalHome, err := os.UserHomeDir()
+	require.NoError(t, err)
+	t.Setenv("HOME", tmpDir)
+	defer t.Setenv("HOME", originalHome)
+
+	// Override API URL to point to our mock server
+	originalAPIURL := apiURL
+	apiURL = server.URL
+	defer func() { apiURL = originalAPIURL }()
+
+	// Provide a token directly to bypass config file logic
+	originalAccessTokens := accessTokens
+	accessTokens = []string{"test-token"}
+	defer func() { accessTokens = originalAccessTokens }()
+
+	// Reset kubeConfigPath flag to ensure it uses the default path within our temp HOME
+	originalKubeConfigPath := kubeConfigPath
+	kubeConfigPath = ""
+	defer func() { kubeConfigPath = originalKubeConfigPath }()
+
+	// Enable verbose logging to check output
+	verbose = true
+	defer func() { verbose = false }()
+
+	// 3. Run the command
+	err = syncCmd.RunE(syncCmd, []string{})
+	require.NoError(t, err)
+
+	// 4. Verify the results
+	updatedBytes, err := os.ReadFile(finalKubeConfigPath)
+	require.NoError(t, err)
+
+	updatedKubeconfig, err := k8sclientcmd.Load(updatedBytes)
+	require.NoError(t, err)
+
+	// Verify that the cluster was updated, not just added
+	assert.Len(t, updatedKubeconfig.Clusters, 1, "There should be only one cluster in the config")
+	updatedCluster, exists := updatedKubeconfig.Clusters["do-nyc1-doks-recreated-cluster"]
+	require.True(t, exists, "Recreated cluster should exist in config")
+
+	// Verify the server URL has been updated
+	assert.Equal(t, "https://new-recreated-cluster-server", updatedCluster.Server, "Cluster server URL should be updated")
+
+	// Verify the cluster ID has been updated
+	newID, found := kubeconfig.GetClusterID(updatedCluster)
+	assert.True(t, found, "Cluster ID extension should be found")
+	assert.Equal(t, "new-recreated-cluster-id", newID, "Cluster ID should be updated to the new ID")
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.11.0
 	github.com/stretchr/testify v1.10.0
+	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
 )
 
@@ -46,7 +47,6 @@ require (
 	gopkg.in/ini.v1 v1.66.4 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.33.2 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 // indirect
 	sigs.k8s.io/json v0.0.0-20241010143419-9aa6b5e7a4b3 // indirect

--- a/pkg/kubeconfig/extension.go
+++ b/pkg/kubeconfig/extension.go
@@ -1,0 +1,42 @@
+package kubeconfig
+
+import (
+	"encoding/json"
+
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// DigitalOceanClusterIDExtension is the name of the extension used to store the DigitalOcean cluster ID.
+const DigitalOceanClusterIDExtension = "digitalocean.com/cluster-id"
+
+// GetClusterID retrieves the DigitalOcean cluster ID from a kubeconfig cluster's extensions.
+// It returns the ID and true if the extension is found, otherwise it returns an empty string and false.
+func GetClusterID(cluster *api.Cluster) (string, bool) {
+	extension, ok := cluster.Extensions[DigitalOceanClusterIDExtension]
+	if !ok {
+		return "", false
+	}
+
+	unknown, ok := extension.(*runtime.Unknown)
+	if !ok {
+		return "", false
+	}
+
+	var data map[string]string
+	if err := json.Unmarshal(unknown.Raw, &data); err != nil {
+		return "", false
+	}
+
+	id, ok := data["id"]
+	return id, ok
+}
+
+// SetClusterID adds or updates the DigitalOcean cluster ID in a kubeconfig cluster's extensions.
+func SetClusterID(cluster *api.Cluster, id string) {
+	if cluster.Extensions == nil {
+		cluster.Extensions = make(map[string]runtime.Object)
+	}
+
+	cluster.Extensions[DigitalOceanClusterIDExtension] = &runtime.Unknown{Raw: []byte(`{"id":"` + id + `"}`)}
+}

--- a/pkg/kubeconfig/extension_test.go
+++ b/pkg/kubeconfig/extension_test.go
@@ -1,0 +1,85 @@
+package kubeconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetClusterID(t *testing.T) {
+	tests := []struct {
+		name          string
+		cluster       *api.Cluster
+		expectedID    string
+		expectedFound bool
+	}{
+		{
+			name:          "no extensions",
+			cluster:       &api.Cluster{},
+			expectedID:    "",
+			expectedFound: false,
+		},
+		{
+			name: "extension exists",
+			cluster: &api.Cluster{
+				Extensions: map[string]runtime.Object{
+					DigitalOceanClusterIDExtension: &runtime.Unknown{Raw: []byte(`{"id":"test-id"}`)},
+				},
+			},
+			expectedID:    "test-id",
+			expectedFound: true,
+		},
+		{
+			name: "other extensions exist",
+			cluster: &api.Cluster{
+				Extensions: map[string]runtime.Object{
+					"other-extension": &runtime.Unknown{Raw: []byte(`{"key":"value"}`)},
+				},
+			},
+			expectedID:    "",
+			expectedFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, found := GetClusterID(tt.cluster)
+			assert.Equal(t, tt.expectedID, id)
+			assert.Equal(t, tt.expectedFound, found)
+		})
+	}
+}
+
+func TestSetClusterID(t *testing.T) {
+	tests := []struct {
+		name    string
+		cluster *api.Cluster
+		idToSet string
+	}{
+		{
+			name:    "add to new cluster",
+			cluster: &api.Cluster{},
+			idToSet: "new-id",
+		},
+		{
+			name: "update existing extension",
+			cluster: &api.Cluster{
+				Extensions: map[string]runtime.Object{
+					DigitalOceanClusterIDExtension: &runtime.Unknown{Raw: []byte(`{"id":"old-id"}`)},
+				},
+			},
+			idToSet: "updated-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetClusterID(tt.cluster, tt.idToSet)
+			id, found := GetClusterID(tt.cluster)
+			assert.True(t, found)
+			assert.Equal(t, tt.idToSet, id)
+		})
+	}
+}


### PR DESCRIPTION
This pull request enhances the sync command to reliably handle DigitalOcean Kubernetes clusters that have been deleted and recreated with the same name.

Previously, the sync command only checked for the existence of a context by name. This meant that if a cluster was recreated, kubectl-doks would not detect the change, leaving the kubeconfig with stale credentials and a pointing to a non-existent server.

This PR introduces the following changes:

- **Cluster ID Extension:** A new `digitalocean.com/cluster-id` extension is now stored in the kubeconfig for each cluster managed by kubectl-doks.
- **Enhanced sync Logic:** The sync command now compares the cluster ID from the DigitalOcean API with the ID stored in the kubeconfig extension. If the IDs do not match, it correctly identifies the cluster as having been recreated and updates the kubeconfig with the new credentials and server information.
- **Updated save Command:** The save command has been updated to write the cluster ID extension when adding new clusters to the kubeconfig.
- **Bug Fix:** Fixes a bug in the sync command's verbose output where it reported the total number of clusters on the account instead of the number of clusters that were actually added or updated.