### PR TITLE
Add Kubeconfig Expiration and Force Flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,17 @@ kubectl doks kubeconfig save [<cluster-name>] [flags]
 
 ## Flags
 
-| Flag | Description | Applicable To |
-| --- | --- | --- |
-| `-t`, `--access-token` | DigitalOcean API V2 token (can be specified multiple times) | global |
-| `-u`, `--api-url` | Override the default DigitalOcean API endpoint | global |
-| `-c`, `--config` | Path to `doctl` config file | global |
-| `--auth-context` | Use this `doctl` authentication context (can be specified multiple times) | global |
-| `--all-auth-contexts` | Include all `doctl` authentication contexts | global |
-| `-v`, `--verbose` | Enable verbose output (reports added/removed contexts, teams queried, etc.) | global |
-| `--set-current-context` | Set `current-context` after a `save` or `sync` operation (default: `true`). See command descriptions for specific behavior. | global |
+| Flag | Description |
+| --- | --- |
+| `--access-token` `-t` | DigitalOcean API V2 token (can be specified multiple times) |
+| `--all-auth-contexts` | Include all `doctl` authentication contexts |
+| `--api-url` `-u` | Override the default DigitalOcean API endpoint |
+| `--auth-context` | Use this `doctl` authentication context (can be specified multiple times) |
+| `--config` `-c` | Path to `doctl` config file |
+| `--expiry-seconds` | The number of seconds until the kubeconfig expires. A value of `0` means the token never expire and is the default. |
+| `--force` `-f` | Force resync of kubeconfig even if it is up-to-date. |
+| `--set-current-context` | Set `current-context` after a `save` or `sync` operation (default: `true`). See command descriptions for specific behavior. |
+| `--verbose` `-v` | Enable verbose output (reports added/removed contexts, teams queried, etc.) |
 
 **Notes**:
 
@@ -155,6 +157,12 @@ kubectl doks kubeconfig save --auth-context test-team-1 --auth-context test-team
 
 # Save a single cluster but prevent changing the current context.
 kubectl doks kubeconfig save my-cluster-name --set-current-context=false
+
+# Save credentials for a single cluster with a 1-hour expiration.
+kubectl doks kubeconfig save my-cluster-name --expiry-seconds=3600
+
+# Force a sync of all clusters, even if they are already in the kubeconfig.
+kubectl doks kubeconfig sync --force
 ```
 
 ---

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ var (
 	configFile      string
 	verbose           bool
 	setCurrentContext bool
+	expirySeconds     int
+	force             bool
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -51,6 +53,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&configFile, "config", "c", "", "Path to doctl config file (default: $HOME/.config/doctl/config.yaml)")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.PersistentFlags().BoolVar(&setCurrentContext, "set-current-context", true, "Set current-context after a successful save or sync")
+	rootCmd.PersistentFlags().IntVar(&expirySeconds, "expiry-seconds", 0, "The number of seconds until the kubeconfig expires. 0 means no expiration.")
+	rootCmd.PersistentFlags().BoolVarP(&force, "force", "f", false, "Force resync of kubeconfig even if it is up-to-date")
 }
 
 // validateAuthFlags ensures that at least one authentication method is specified.

--- a/do/client.go
+++ b/do/client.go
@@ -91,12 +91,12 @@ func (c *Client) ListClusters(ctx context.Context) ([]Cluster, error) {
 }
 
 // GetKubeConfig returns the kubeconfig for a specific cluster as a byte array
-func (c *Client) GetKubeConfig(ctx context.Context, clusterID string) ([]byte, error) {
+func (c *Client) GetKubeConfig(ctx context.Context, clusterID string, expirySeconds int) ([]byte, error) {
 	if strings.TrimSpace(clusterID) == "" {
 		return nil, errors.New("cluster ID cannot be empty")
 	}
 
-	kubeConfig, _, err := c.godoClient.Kubernetes.GetKubeConfig(ctx, clusterID)
+	kubeConfig, _, err := c.godoClient.Kubernetes.GetKubeConfigWithExpiry(ctx, clusterID, int64(expirySeconds))
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving kubeconfig for cluster %s: %v", clusterID, err)
 	}


### PR DESCRIPTION
This pull request introduces two new flags to the `kubectl-doks` plugin, providing users with greater control over kubeconfig management: `--expiry-seconds` and `--force`.

#### Key Changes:

*   **Configurable Kubeconfig Expiration (`--expiry-seconds`)**:
    *   A new `--expiry-seconds` flag has been added to the `save` and `sync` commands, allowing users to set a validity period for their kubeconfig credentials.
    *   By default, the value is `0`, which means the kubeconfig never expires, preserving the existing behavior.
    *   The underlying DigitalOcean API call has been updated to `GetKubeConfigWithExpiry` to support this functionality.

*   **Force Kubeconfig Updates (`--force` / `-f`)**:
    *   A new `--force` (shorthand `-f`) flag is now available for both `save` and `sync`.
    *   This flag compels the plugin to update the kubeconfig file, even if it is already considered up-to-date, which is useful for refreshing credentials.

*   **Improved Verbose Output**:
    *   The verbose output (`-v`) for `save` and `sync` has been consolidated to be more concise. It now clearly indicates which contexts are being added and whether an expiration is set in a single, clean message.