### PR TITLE
Fix: Prevent backup creation when kubeconfig doesn't exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ go.work.sum
 .vscode/
 git 
 scratch/
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,72 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+kubectl-doks is a Kubernetes CLI plugin written in Go that manages DigitalOcean Kubernetes (DOKS) kubeconfig entries. It allows users to synchronize all active DOKS clusters to their local `~/.kube/config` file, removing stale contexts and adding new ones.
+
+## Common Commands
+
+### Build and Development
+- `make build` - Build the binary for current platform in `dist/` directory
+- `make build-all` - Build for all platforms (Linux amd64, macOS amd64/arm64)
+- `make test` - Run all tests with verbose output (`go test -v ./...`)
+- `make lint` - Run golangci-lint for code quality checks
+- `make clean` - Remove all built binaries from `dist/`
+
+### Testing
+- `go test ./...` - Run all tests
+- `go test ./cmd` - Test command packages
+- `go test ./pkg/kubeconfig` - Test kubeconfig utilities
+
+### Release
+- `make package-for-krew` - Build and package binaries for Krew distribution
+- `make update-krew-manifest` - Update Krew manifest with new version/checksums
+
+## Architecture
+
+### Core Structure
+- **main.go**: Entry point that calls `cmd.Execute()`
+- **cmd/**: Cobra CLI command definitions and logic
+- **do/**: DigitalOcean API client wrapper using godo library
+- **pkg/kubeconfig/**: Core kubeconfig manipulation utilities
+
+### Key Components
+
+#### Command Structure (cmd/)
+- `root.go`: Base command with global flags and authentication validation
+- `kubeconfig.go`: Parent command for kubeconfig operations
+- `sync.go`: Synchronizes all DOKS clusters (adds new, removes stale)
+- `save.go`: Saves specific cluster or all new clusters without removing stale ones
+- `auth.go`: Authentication utilities for DigitalOcean API
+- `version.go`: Version command
+
+#### Kubeconfig Management (pkg/kubeconfig/)
+- `file.go`: File I/O operations for kubeconfig
+- `merge.go`: Merging cluster credentials into existing kubeconfig
+- `prune.go`: Removing stale contexts from kubeconfig
+- `backup.go`: Creating backups before modifications
+- `extension.go`: Managing DigitalOcean cluster ID extensions in kubeconfig
+
+#### DigitalOcean Integration (do/)
+- `client.go`: API client wrapper with authentication context support
+
+### Key Design Patterns
+- Uses Cobra for CLI structure with persistent flags
+- Implements kubeconfig extensions (`digitalocean.com/cluster-id`) to track cluster identity across recreations
+- Supports multiple authentication methods (API tokens, doctl contexts)
+- Creates automatic backups before kubeconfig modifications
+- Distinguishes between "sync" (add new + remove stale) and "save" (add new only) operations
+
+### Dependencies
+- **cobra**: CLI framework
+- **godo**: DigitalOcean API client
+- **k8s.io/client-go**: Kubernetes client library for kubeconfig handling
+- **viper**: Configuration management
+- **testify**: Testing framework
+
+### Testing Strategy
+- Unit tests for all major components with `_test.go` files
+- Test coverage includes authentication, kubeconfig operations, and API client functionality
+- Uses testify for assertions and mocking

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -90,9 +90,14 @@ If no cluster name is provided, it saves the credentials for all available clust
 				}
 			}
 
-			mergedConfigBytes, err := kubeconfig.MergeConfig(existingConfigBytes, kubeConfigBytes, false) // Always merge with false first
-			if err != nil {
-				return fmt.Errorf("merging kubeconfig for cluster %s: %w", selectedCluster.Name, err)
+			var mergedConfigBytes []byte
+			if len(existingConfigBytes) == 0 {
+				mergedConfigBytes = kubeConfigBytes
+			} else {
+				mergedConfigBytes, err = kubeconfig.MergeConfig(existingConfigBytes, kubeConfigBytes, false) // Always merge with false first
+				if err != nil {
+					return fmt.Errorf("merging kubeconfig for cluster %s: %w", selectedCluster.Name, err)
+				}
 			}
 
 			config, err := k8sclientcmd.Load(mergedConfigBytes)
@@ -150,9 +155,14 @@ If no cluster name is provided, it saves the credentials for all available clust
 					return fmt.Errorf("getting kubeconfig for cluster %s: %w", cluster.Name, err)
 				}
 
-				mergedConfigBytes, err := kubeconfig.MergeConfig(currentConfigBytes, kubeConfigBytes, false)
-				if err != nil {
-					return fmt.Errorf("merging kubeconfig for cluster %s: %w", cluster.Name, err)
+				var mergedConfigBytes []byte
+				if len(currentConfigBytes) == 0 {
+					mergedConfigBytes = kubeConfigBytes
+				} else {
+					mergedConfigBytes, err = kubeconfig.MergeConfig(currentConfigBytes, kubeConfigBytes, false)
+					if err != nil {
+						return fmt.Errorf("merging kubeconfig for cluster %s: %w", cluster.Name, err)
+					}
 				}
 
 				// Reload config object to add extension and check for next cluster

--- a/cmd/save.go
+++ b/cmd/save.go
@@ -81,10 +81,10 @@ If no cluster name is provided, it saves the credentials for all available clust
 			}
 
 			backupPath := kubeConfigPath + ".kubectl-doks.bak"
-			if verbose {
-				fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
-			}
 			if _, err := os.Stat(kubeConfigPath); err == nil {
+				if verbose {
+					fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
+				}
 				if err := kubeconfig.BackupKubeconfig(kubeConfigPath, backupPath); err != nil {
 					return fmt.Errorf("backing up kubeconfig: %w", err)
 				}
@@ -185,10 +185,10 @@ If no cluster name is provided, it saves the credentials for all available clust
 
 			if len(addedContexts) > 0 {
 				backupPath := kubeConfigPath + ".kubectl-doks.bak"
-				if verbose {
-					fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
-				}
 				if _, err := os.Stat(kubeConfigPath); err == nil {
+					if verbose {
+						fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
+					}
 					if err := kubeconfig.BackupKubeconfig(kubeConfigPath, backupPath); err != nil {
 						return fmt.Errorf("backing up kubeconfig: %w", err)
 					}

--- a/cmd/save_test.go
+++ b/cmd/save_test.go
@@ -211,6 +211,143 @@ func TestSaveCommandWithForce(t *testing.T) {
 	assert.NoError(t, err, "Backup file should be created when --force is used")
 }
 
+func TestSaveCommandWithMissingKubeconfig(t *testing.T) {
+	// 1. Create a mock API server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v2/kubernetes/clusters" {
+			clusters := []*godo.KubernetesCluster{
+				{
+					ID:         "new-cluster-id",
+					Name:       "new-cluster",
+					RegionSlug: "sfo3",
+				},
+			}
+			response := struct {
+				KubernetesClusters []*godo.KubernetesCluster `json:"kubernetes_clusters"`
+			}{
+				KubernetesClusters: clusters,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			require.NoError(t, json.NewEncoder(w).Encode(response))
+		} else if r.URL.Path == "/v2/kubernetes/clusters/new-cluster-id/kubeconfig" {
+			fmt.Fprint(w, mockKubeconfigForSave)
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	t.Run("save specific cluster when kubeconfig doesn't exist", func(t *testing.T) {
+		// 2. Set up temporary environment and flags
+		tmpDir := t.TempDir()
+
+		kubeConfigDir := filepath.Join(tmpDir, ".kube")
+		require.NoError(t, os.MkdirAll(kubeConfigDir, 0755))
+		finalKubeConfigPath := filepath.Join(kubeConfigDir, "config")
+		// Don't create the kubeconfig file - it should not exist
+
+		originalHome, err := os.UserHomeDir()
+		require.NoError(t, err)
+		t.Setenv("HOME", tmpDir)
+		defer t.Setenv("HOME", originalHome)
+
+		originalAPIURL := apiURL
+		apiURL = server.URL
+		defer func() { apiURL = originalAPIURL }()
+
+		originalAccessTokens := accessTokens
+		accessTokens = []string{"test-token"}
+		defer func() { accessTokens = originalAccessTokens }()
+
+		originalKubeConfigPath := kubeConfigPath
+		kubeConfigPath = ""
+		defer func() { kubeConfigPath = originalKubeConfigPath }()
+
+		// 3. Run the command
+		err = saveCmd.RunE(saveCmd, []string{"new-cluster"})
+		require.NoError(t, err)
+
+		// 4. Verify the results
+		updatedBytes, err := os.ReadFile(finalKubeConfigPath)
+		require.NoError(t, err)
+
+		updatedKubeconfig, err := k8sclientcmd.Load(updatedBytes)
+		require.NoError(t, err)
+
+		// Verify new context
+		assert.Contains(t, updatedKubeconfig.Contexts, "do-sfo3-new-cluster", "Context for new cluster should exist")
+		// Verify new cluster
+		assert.Contains(t, updatedKubeconfig.Clusters, "do-sfo3-new-cluster", "New cluster should exist")
+		// Verify new user
+		assert.Contains(t, updatedKubeconfig.AuthInfos, "do-sfo3-new-cluster-admin", "User for new cluster should exist")
+
+		// Verify cluster ID extension
+		newCluster, exists := updatedKubeconfig.Clusters["do-sfo3-new-cluster"]
+		require.True(t, exists, "New cluster config should exist")
+		id, found := kubeconfig.GetClusterID(newCluster)
+		assert.True(t, found, "Cluster ID extension should be found")
+		assert.Equal(t, "new-cluster-id", id, "Cluster ID should match")
+
+		// Verify there's only one context (no old contexts)
+		assert.Len(t, updatedKubeconfig.Contexts, 1, "Should only have one context")
+	})
+
+	t.Run("save all clusters when kubeconfig doesn't exist", func(t *testing.T) {
+		// 2. Set up temporary environment and flags
+		tmpDir := t.TempDir()
+
+		kubeConfigDir := filepath.Join(tmpDir, ".kube")
+		require.NoError(t, os.MkdirAll(kubeConfigDir, 0755))
+		finalKubeConfigPath := filepath.Join(kubeConfigDir, "config")
+		// Don't create the kubeconfig file - it should not exist
+
+		originalHome, err := os.UserHomeDir()
+		require.NoError(t, err)
+		t.Setenv("HOME", tmpDir)
+		defer t.Setenv("HOME", originalHome)
+
+		originalAPIURL := apiURL
+		apiURL = server.URL
+		defer func() { apiURL = originalAPIURL }()
+
+		originalAccessTokens := accessTokens
+		accessTokens = []string{"test-token"}
+		defer func() { accessTokens = originalAccessTokens }()
+
+		originalKubeConfigPath := kubeConfigPath
+		kubeConfigPath = ""
+		defer func() { kubeConfigPath = originalKubeConfigPath }()
+
+		// 3. Run the command (no cluster name = save all)
+		err = saveCmd.RunE(saveCmd, []string{})
+		require.NoError(t, err)
+
+		// 4. Verify the results
+		updatedBytes, err := os.ReadFile(finalKubeConfigPath)
+		require.NoError(t, err)
+
+		updatedKubeconfig, err := k8sclientcmd.Load(updatedBytes)
+		require.NoError(t, err)
+
+		// Verify new context
+		assert.Contains(t, updatedKubeconfig.Contexts, "do-sfo3-new-cluster", "Context for new cluster should exist")
+		// Verify new cluster
+		assert.Contains(t, updatedKubeconfig.Clusters, "do-sfo3-new-cluster", "New cluster should exist")
+		// Verify new user
+		assert.Contains(t, updatedKubeconfig.AuthInfos, "do-sfo3-new-cluster-admin", "User for new cluster should exist")
+
+		// Verify cluster ID extension
+		newCluster, exists := updatedKubeconfig.Clusters["do-sfo3-new-cluster"]
+		require.True(t, exists, "New cluster config should exist")
+		id, found := kubeconfig.GetClusterID(newCluster)
+		assert.True(t, found, "Cluster ID extension should be found")
+		assert.Equal(t, "new-cluster-id", id, "Cluster ID should match")
+
+		// Verify there's only one context (no old contexts)
+		assert.Len(t, updatedKubeconfig.Contexts, 1, "Should only have one context")
+	})
+}
+
 func TestSaveCommandContextHandling(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/v2/kubernetes/clusters" {

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -131,10 +131,10 @@ is synchronized with the clusters' credentials.`,
 
 		if len(removedContexts) > 0 || len(addedContexts) > 0 {
 			backupPath := kubeConfigPath + ".kubectl-doks.bak"
-			if verbose {
-				fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
-			}
 			if _, err := os.Stat(kubeConfigPath); err == nil {
+				if verbose {
+					fmt.Printf("Notice: Creating backup of kubeconfig at %s\n", backupPath)
+				}
 				if err := kubeconfig.BackupKubeconfig(kubeConfigPath, backupPath); err != nil {
 					return fmt.Errorf("backing up kubeconfig: %w", err)
 				}


### PR DESCRIPTION
- Fixed issue where save and sync commands attempted to create backups even when the kubeconfig file didn't exist
- Added proper handling for missing kubeconfig files in both save and sync operations
- Added comprehensive test coverage for the missing kubeconfig scenarios